### PR TITLE
Update header.html

### DIFF
--- a/vraptor-site/layouts/header.html
+++ b/vraptor-site/layouts/header.html
@@ -9,7 +9,7 @@
   <div class="header-links">
     <ul class="community">
 
-      <li><a href="https://groups.google.com/forum/<%=path == 'en' ? '?hl=en#!forum/vraptor4' : '#!forum/caelum-vraptor'%>" target="_blank">Google Groups</a></li>
+      <li><a href="https://groups.google.com/forum/#!forum/caelum-vraptor>" target="_blank">Google Groups</a></li>
 
       <li><a href="https://github.com/caelum/vraptor4/" target="_blank">GitHub</a></li>
 


### PR DESCRIPTION
Correcting the english version link to Google Groups. Notive that the english version had another behavior, but this was proposed in the user list (https://groups.google.com/forum/#!topic/caelum-vraptor/kfYMTMxKoUk), once the most used list is caelum-vraptor.
